### PR TITLE
fix updateEvent failing

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,15 +19,15 @@ GitEventsTito.prototype.createEvent = function createEvent (payload, cb) {
   async.waterfall([
     function(cb) { self.getLatestEvent(cb); },
     function(event, cb) { self.duplicateEvent(event, cb); },
-    function(duplicatedEvent, cb) { self.updateEvent(payload, cb); }
+    function(duplicatedEvent, cb) { self.updateEvent(duplicatedEvent, payload, cb); }
   ], cb)
 }
 
-GitEventsTito.prototype.updateEvent = function updateEvent (payload, cb) {
+GitEventsTito.prototype.updateEvent = function updateEvent (duplicatedEvent, payload, cb) {
   var updatedEvent;
 
   var titoUpdateEvent = function(err, eventDetails){
-    this.tito.updateEvent(eventDetails.slug, eventDetails)
+    this.tito.updateEvent(duplicatedEvent.attributes.slug, eventDetails)
       .on('data', function(data) { updatedEvent = data; })
       .on('end', function() { cb(null, updatedEvent); })
   }
@@ -74,11 +74,9 @@ GitEventsTito.prototype.getEventDetails = function getEventDetails (payload, cb)
       var startDate = moment(body.attributes.date.replace(/\//g, ' '), "DD MM YYYY").format();
 
       cb(null, {
-        data: {
-          slug: slug,
-          'start-date': startDate
-        }
-      })
+        slug: slug,
+        'start-date': startDate
+      });
     }
 
     return new Error('invalid event info - body contains no attributes.');

--- a/test.js
+++ b/test.js
@@ -19,8 +19,8 @@ test('getEventDetails', function(t) {
   t.plan(2)
 
   tito.getEventDetails(payload, function(err, eventDetails) {
-    t.equal(eventDetails.data.slug, 'december-2099')
-    t.equal(eventDetails.data['start-date'], '2099-12-31T00:00:00+00:00')
+    t.equal(eventDetails.slug, 'december-2099')
+    t.equal(eventDetails['start-date'], '2099-12-31T00:00:00+00:00')
   })
 })
 
@@ -88,6 +88,12 @@ test('duplicateEvent', function (t) {
 test('updateEvent', function (t) {
   t.plan(1);
 
+  var originalEvent = {
+    attributes: {
+      slug: 'december-2099'
+    }
+  }
+
   var updatedEvent = {
     attributes: {
       date: '2099-12-31T00:00:00+00:00'
@@ -100,7 +106,7 @@ test('updateEvent', function (t) {
       data: updatedEvent
     })
 
-  tito.updateEvent(payload, function(err, event) {
+  tito.updateEvent(originalEvent, payload, function(err, event) {
     t.deepEqual(event, updatedEvent);
   })
 });


### PR DESCRIPTION
`updateEvent` was failing due to not receiving the duplicated event. This PR fixes this.
